### PR TITLE
Support additionanl options for mongoose.connect in config file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,12 +21,14 @@ module.exports = {
   development: {
     schema: { 'migration': {} },
     modelName: 'Migration',
-    db: process.env.MONGOHQ_URL || 'mongodb://localhost/app_development'
+    db: process.env.MONGOHQ_URL || 'mongodb://localhost/app_development',
+    dbOptions: { ... }
   },
   test: { ... },
   production: { ... }
 }
 ```
+> `dbOptions` is an optional argument for `mongoose.connect`
 
 and then run the migrate command
 

--- a/lib/set.js
+++ b/lib/set.js
@@ -74,7 +74,7 @@ var config = json[env];
 var Schema = mongoose.Schema;
 var MigrationSchema = new Schema(config.schema);
 var Migration;
-mongoose.connect(config.db);
+mongoose.connect(config.db, config.dbOptions);
 
 /**
  * Connect to mongo


### PR DESCRIPTION
MongoDB with SSL, for example, would require passing options to `mongoose.connect`. This patch allows users to specify the options in `dbOptions`
